### PR TITLE
POC: Make assignment expressions and function calls safe

### DIFF
--- a/foo.ts
+++ b/foo.ts
@@ -2,11 +2,21 @@ class Animal {}
 class Dog extends Animal { bark() {} }
 class Cat extends Animal { purr() {} }
 
-const cats: Array<Cat> = [new Cat];
-const badCats: Array<Cat> = [];
-const goodAnimals: Array<Animal> = [new Cat, new Dog];
+const cats: Cat[] = [];
+const badCats: Cat[] = [];
+const goodAnimals: Animal[] = [new Cat, new Dog];
 const readonlyAnimals: ReadonlyArray<Animal> = cats;
-const badAnimals: Array<Animal> = cats; // error
+const badAnimals: Animal[] = cats; // error
+
+const foo = (animals: Animal[]) => {};
+foo(goodAnimals);
+foo([new Cat]);
+foo(cats); // error
+
+const bar = (animals: ReadonlyArray<Animal>) => {};
+bar(goodAnimals);
+bar(cats);
+bar([new Cat]);
 
 badAnimals.push(new Dog);
 // Unsound and bad

--- a/foo.ts
+++ b/foo.ts
@@ -31,10 +31,19 @@ const readonlyMixedNode: Readonly<MixedNode> = numNode; // this is okay
 
 const mixedNodeFunc = (node: MixedNode) => {};
 mixedNodeFunc(goodMixedNode);
-mixedNodeFunc(numNode);
+mixedNodeFunc(numNode); // error, mixedNodeFunc could mutate numNode to set "id" to be a string
 mixedNodeFunc({ id: 5 });
 
 const readonlyMixedNodeFunc = (node: Readonly<MixedNode>) => {};
 readonlyMixedNodeFunc(goodMixedNode);
 readonlyMixedNodeFunc(numNode);
 readonlyMixedNodeFunc({ id: 5 });
+
+type CatNode = { animal: Cat };
+type AnimalNode = { animal: Animal };
+const catNode: CatNode = { animal: new Cat };
+const goodAnimalNode: AnimalNode = { animal: new Cat };
+const badAnimalNode: AnimalNode = catNode; // error
+
+// const a: number = 5;
+// const b: number | string = a;

--- a/foo.ts
+++ b/foo.ts
@@ -1,0 +1,13 @@
+class Animal {}
+class Dog extends Animal { bark() {} }
+class Cat extends Animal { purr() {} }
+
+const cats: Array<Cat> = [new Cat];
+const badCats: Array<Cat> = [];
+const goodAnimals: Array<Animal> = [new Cat, new Dog];
+const readonlyAnimals: ReadonlyArray<Animal> = cats;
+const badAnimals: Array<Animal> = cats; // error
+
+badAnimals.push(new Dog);
+// Unsound and bad
+cats.forEach(cat => cat.purr());

--- a/foo.ts
+++ b/foo.ts
@@ -2,8 +2,7 @@ class Animal {}
 class Dog extends Animal { bark() {} }
 class Cat extends Animal { purr() {} }
 
-const cats: Cat[] = [];
-const badCats: Cat[] = [];
+const cats: Cat[] = [new Cat];
 const goodAnimals: Animal[] = [new Cat, new Dog];
 const readonlyAnimals: ReadonlyArray<Animal> = cats;
 const badAnimals: Animal[] = cats; // error
@@ -21,3 +20,21 @@ bar([new Cat]);
 badAnimals.push(new Dog);
 // Unsound and bad
 cats.forEach(cat => cat.purr());
+
+type NumberNode = { id: number };
+type MixedNode = { id: number | string };
+const numNode: NumberNode = { id: 5 };
+const goodMixedNode: MixedNode = { id: 5 };
+const badMixedNode: MixedNode = numNode; // error
+badMixedNode.id = "five"; // whoops, now node0 has a string for its "id"
+const readonlyMixedNode: Readonly<MixedNode> = numNode; // this is okay
+
+const mixedNodeFunc = (node: MixedNode) => {};
+mixedNodeFunc(goodMixedNode);
+mixedNodeFunc(numNode);
+mixedNodeFunc({ id: 5 });
+
+const readonlyMixedNodeFunc = (node: Readonly<MixedNode>) => {};
+readonlyMixedNodeFunc(goodMixedNode);
+readonlyMixedNodeFunc(numNode);
+readonlyMixedNodeFunc({ id: 5 });

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -7259,7 +7259,16 @@ namespace ts {
         return !!(options.incremental || options.composite);
     }
 
-    export type StrictOptionName = "noImplicitAny" | "noImplicitThis" | "strictNullChecks" | "strictFunctionTypes" | "strictBindCallApply" | "strictPropertyInitialization" | "alwaysStrict";
+    export type StrictOptionName = 
+        | "noImplicitAny" 
+        | "noImplicitThis" 
+        | "strictNullChecks" 
+        | "strictFunctionTypes" 
+        | "strictBindCallApply" 
+        | "strictPropertyInitialization" 
+        | "strictAliasAssignment"
+        | "strictAliasArgs"
+        | "alwaysStrict";
 
     export function getStrictOptionValue(compilerOptions: CompilerOptions, flag: StrictOptionName): boolean {
         return compilerOptions[flag] === undefined ? !!compilerOptions.strict : !!compilerOptions[flag];


### PR DESCRIPTION
This prevents unsafe operations since mutable covariant arrays can no longer be assigned to their contravariant.

This refactored `isRelatedTo` and similar functions to accept an options object which made feeding the current node, `errorNode`, down to `recursiveTypeRelatedTo` before computing `variances` to override the default variance for type parameters which is now `invariant` to be `covariant` for array literals only.

It also updates `getRelationKey` to also take an `errorNode` which is used to differentiate the relation key when the source is an array literal.  This allows `isTypeRelatedTo` to return different results depending on whether an array literal or a non-literal array with the same type are the source.

TODO: 
- [x] make function calls work so that passing literals is covariant while passing variables (to mutable params) is invariant
- [ ] place this new behavior behind a flag
- [ ] run the existing test suite and make sure nothing's broken
- [ ] add new tests for the new behavior

Test Plan:
- yarn gulp build-min
- node built/local/tsc.js --skipLibCheck --strict --noEmit foo.ts
- see the following (expected) errors:
```
foo.ts:9:7 - error TS2322: Type 'Cat[]' is not assignable to type 'Animal[]'.

9 const badAnimals: Animal[] = cats; // error
        ~~~~~~~~~~

foo.ts:9:30 - error TS2322: Type 'Cat[]' is not assignable to type 'Animal[]'.
  Property 'purr' is missing in type 'Animal' but required in type 'Cat'.

9 const badAnimals: Animal[] = cats; // error
                               ~~~~

  foo.ts:3:28
    3 class Cat extends Animal { purr() {} }
                                 ~~~~
    'purr' is declared here.

foo.ts:13:5 - error TS2345: Argument of type 'Cat[]' is not assignable to parameter of type 'Animal[]'.

13 foo(cats); // error
       ~~~~


Found 3 errors.
```
foo.ts:
```typescript
class Animal {}
class Dog extends Animal { bark() {} }
class Cat extends Animal { purr() {} }

const cats: Cat[] = [new Cat];
const goodAnimals: Animal[] = [new Cat, new Dog];
const readonlyAnimals: ReadonlyArray<Animal> = cats;
const badAnimals: Animal[] = cats; // error

const foo = (animals: Animal[]) => {};
foo(goodAnimals);
foo([new Cat]);
foo(cats); // error

const bar = (animals: ReadonlyArray<Animal>) => {};
bar(goodAnimals);
bar([new Cat]);
bar(cats);

badAnimals.push(new Dog);
// Unsound and bad
// This should never be possible, because `badAnimals = cats` will be flagged as an error.
cats.forEach(cat => cat.purr());
```